### PR TITLE
Get sensor readings

### DIFF
--- a/Flask/app/admin/views/node.py
+++ b/Flask/app/admin/views/node.py
@@ -149,9 +149,7 @@ def upload_data(id):
         new_data_df.index = pd.to_datetime(new_data_df.index)
         new_data_df.index.name = "timestamp"
 
-        folder_location = current_app.config['DATA_ROOT_PATH']
         newdir = os.path.join(content_folder("DATA_ROOT", id, "FLASK", upload=True))
-        # newdir = (os.path.join(folder_location, id))  # content_folder function when merged with main
 
         try:
             df = pd.read_csv(os.path.join(newdir, cube_level + '.csv'), index_col="timestamp")
@@ -160,7 +158,8 @@ def upload_data(id):
             df = new_data_df
         df.to_csv(os.path.join(newdir, cube_level + '.csv'))
 
-    return j
+    message = "Node Data uploaded"
+    return jsonify({"message" : message})
 
 
 @admin.route('/node/latest/<int:node_id>', methods=['GET'])


### PR DESCRIPTION
The code reads the correct .csv files (top, middle, bottom) and gets the latest reports (lowest row in the csv file using tail function of pandas). Then returns it in json as follows: 

{
    "bottom": {
        "air_temp": 33.33,
        "ec": 35900.0,
        "humidity": 88.0,
        "lux": 13144.0,
        "moisture": 67.0,
        "pH": 7.87,
        "pressure": 990.0,
        "sub_temp": 13.45,
        "water_level": 3.43
    },
    "middle": {
        "air_temp": 55.66,
        "ec": 25600.0,
        "humidity": 88.0,
        "lux": 1234.0,
        "moisture": 67.0,
        "pH": 7.87,
        "pressure": 990.0,
        "sub_temp": 13.45,
        "water_level": 3.43
    },
    "top": {
        "air_temp": 44.44,
        "ec": 14488.0,
        "humidity": 77.0,
        "lux": 4434.0,
        "moisture": 63.0,
        "pH": 7.97,
        "pressure": 490.0,
        "sub_temp": 23.45,
        "water_level": 3.43
    }
}

There's 2 issues though. 
1)the order of top/middle/bottom is reversed, even though I tried different methods, so it's represented as bottom,middle,top. 2)Also the order of the quantities change, it keeps the same order as the dataframe 

"air_temp": 44.44,
"ec": 14488.0,
"humidity": 77.0,
"lux": 4434.0,
"moisture": 63.0,
"pH": 7.97,
"pressure": 490.0,
"sub_temp": 23.45,
"water_level": 3.43

instead of the order requested 

"air_temp": 19.5,
"humidity": 88.9,
"lux": 40321.0,
"pressure": 899.5,
"sub_temp": 18.4,
"moisture": 78.0,
"ec": 33962.0,
"pH": 7.8,
"water_level": 54.8